### PR TITLE
remove cuda context

### DIFF
--- a/adet/layers/csrc/DeformAttn/ms_deform_attn_cpu.cpp
+++ b/adet/layers/csrc/DeformAttn/ms_deform_attn_cpu.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
 
 
 at::Tensor


### PR DESCRIPTION
installation was failing with the following error: 

```
/root/.../lib/python3.8/site-packages/torch/include/ATen/cuda/CUDAContext.h:5:10: fatal error: cuda_runtime_api.h: No such file or directory
    5 | #include <cuda_runtime_api.h>
```